### PR TITLE
[Fix] drop required node to 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18, 19]
+        node-version: [12, 14, 16, 18, 19]
 
     steps:
       - uses: actions/checkout@v3

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 const { request, stream, setGlobalDispatcher, Agent } = require('undici')
-const EE = require('node:events')
-const fs = require('node:fs')
-const path = require('node:path')
+const EE = require('events')
+const fs = require('fs')
+const path = require('path')
 const debug = require('debug')('is-my-node-vulnerable')
 const satisfies = require('semver/functions/satisfies')
 const { danger, vulnerableWarning, bold, separator, allGood } = require('./ascii')

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "devDependencies": {
     "standard": "^17.0.0"
+  },
+  "engines": {
+    "node": ">= 12"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert')
+const assert = require('assert')
 const { isNodeVulnerable } = require('./index')
 
 async function t () {


### PR DESCRIPTION
Fixes #2

More than happy to drop this further; it seems to be merely minor syntax issues that prevents it from helping even older node users see their vulnerabilities.