### PR TITLE
feat: added platform validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ const { isNodeVulnerable } = require('is-my-node-vulnerable')
 isNodeVulnerable('19.0.0') // true
 ```
 
+Optionally you can define the platform with the argument `platform` to limit the scope. The available platforms are [the same values](https://nodejs.org/api/os.html#osplatform) available in for `os.platform()`.
+
+```js
+const { isNodeVulnerable } = require('is-my-node-vulnerable')
+
+isNodeVulnerable('19.0.0', 'linux') // true
+```
+
 [Node.js Security Database]: https://github.com/nodejs/security-wg/tree/main/vuln
 
 
@@ -101,4 +109,15 @@ jobs:
         uses: RafaelGSS/is-my-node-vulnerable@v1.2.0
         with:
           node-version: "18.14.1"
+```
+
+Optionally you can define the platform with the argument `platform` to limit the scope. The available platforms are [the same values](https://nodejs.org/api/os.html#osplatform) available in for `os.platform()`.
+
+```yml
+      - uses: actions/checkout@v3
+      - name: Check Node.js
+        uses: RafaelGSS/is-my-node-vulnerable@v1.2.0
+        with:
+          node-version: "18.14.1"
+          platform: "linux"
 ```

--- a/action.js
+++ b/action.js
@@ -5,7 +5,7 @@ async function run () {
   // Inputs
   const nodeVersion = core.getInput('node-version', { required: true })
   const platform = core.getInput('platform', { required: false })
-  const availablePlatforms = ['linux', 'win', 'osx', 'smartos', 'aix', 'freebsd']
+  const availablePlatforms = ["aix", "darwin", "freebsd", "linux", "openbsd", "sunos", "win32", "android"]
 
   if (platform && !availablePlatforms.includes(platform)) {
     core.setFailed(`platform ${platform} is not valid. Please use ${availablePlatforms.join(',')}.`)

--- a/action.js
+++ b/action.js
@@ -5,9 +5,10 @@ async function run () {
   // Inputs
   const nodeVersion = core.getInput('node-version', { required: true })
   const platform = core.getInput('platform', { required: false })
+  const availablePlatforms = ['linux', 'win', 'osx', 'smartos', 'aix', 'freebsd']
 
-  if (platform && !['linux', 'win', 'osx'].includes(platform)) {
-    core.setFailed(`platform ${platform} is not valid. Please use linux, win or osx.`)
+  if (platform && !availablePlatforms.includes(platform)) {
+    core.setFailed(`platform ${platform} is not valid. Please use ${availablePlatforms.join(',')}.`)
     return
   }
 

--- a/action.js
+++ b/action.js
@@ -5,12 +5,6 @@ async function run () {
   // Inputs
   const nodeVersion = core.getInput('node-version', { required: true })
   const platform = core.getInput('platform', { required: false })
-  const availablePlatforms = ["aix", "darwin", "freebsd", "linux", "openbsd", "sunos", "win32", "android"]
-
-  if (platform && !availablePlatforms.includes(platform)) {
-    core.setFailed(`platform ${platform} is not valid. Please use ${availablePlatforms.join(',')}.`)
-    return
-  }
 
   core.info(`Checking Node.js version ${nodeVersion} with platform ${platform}...`)
   const isVulnerable = await isNodeVulnerable(nodeVersion, platform)

--- a/action.js
+++ b/action.js
@@ -8,6 +8,7 @@ async function run () {
 
   if (platform && !['linux', 'win', 'osx'].includes(platform)) {
     core.setFailed(`platform ${platform} is not valid. Please use linux, win or osx.`)
+    return
   }
 
   core.info(`Checking Node.js version ${nodeVersion} with platform ${platform}...`)

--- a/action.js
+++ b/action.js
@@ -4,8 +4,14 @@ const { isNodeVulnerable } = require('./index')
 async function run () {
   // Inputs
   const nodeVersion = core.getInput('node-version', { required: true })
-  core.info(`Checking Node.js version ${nodeVersion}...`)
-  const isVulnerable = await isNodeVulnerable(nodeVersion)
+  const platform = core.getInput('platform', { required: false })
+
+  if (platform && !['linux', 'win', 'osx'].includes(platform)) {
+    core.setFailed(`platform ${platform} is not valid. Please use linux, win or osx.`)
+  }
+
+  core.info(`Checking Node.js version ${nodeVersion} with platform ${platform}...`)
+  const isVulnerable = await isNodeVulnerable(nodeVersion, platform)
   if (isVulnerable) {
     core.setFailed(`Node.js version ${nodeVersion} is vulnerable. Please upgrade!`)
   } else {

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: 'Node.js version to check'
     required: true
     default: '16.13.0'
+  platform:
+    description: 'Platform to check'
+    required: false
 
 # https://actions-cool.github.io/github-action-branding/
 branding:

--- a/dist/index.js
+++ b/dist/index.js
@@ -117,7 +117,8 @@ function getVulnerabilityList (currentVersion, data, systemEnvironment) {
         !satisfies(currentVersion, vuln.patched)
       ) && (
         (!systemEnvironment || !Array.isArray(vuln.affectedEnvironments)) ||
-        vuln.affectedEnvironments.includes(systemEnvironment)
+        vuln.affectedEnvironments.includes(systemEnvironment) ||
+        vuln.affectedEnvironments.includes('all')
       )
     ) {
       list.push(`${bold(vuln.cve)}: ${vuln.overview}\n${bold('Patched versions')}: ${vuln.patched}`)

--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ function getVulnerabilityList (currentVersion, data, systemEnvironment) {
         !satisfies(currentVersion, vuln.patched)
       ) && (
         (!systemEnvironment || !Array.isArray(vuln.affectedEnvironments)) ||
-        vuln.affectedEnvironments.includes(systemEnvironment)
+        vuln.affectedEnvironments.includes(systemEnvironment) ||
+        vuln.affectedEnvironments.includes('all')
       )
     ) {
       list.push(`${bold(vuln.cve)}: ${vuln.overview}\n${bold('Patched versions')}: ${vuln.patched}`)

--- a/index.js
+++ b/index.js
@@ -80,19 +80,7 @@ function getVulnerabilityList (currentVersion, data, systemEnvironment) {
   return list
 }
 
-const getSystemEnvironment = (platform) => {
-  switch (platform) {
-    case 'darwin':
-      return 'osx'
-    case 'win32':
-      return 'win'
-    default:
-      return 'linux'
-  }
-}
-
 async function main (currentVersion, platform) {
-  const systemEnvironment = getSystemEnvironment(platform)
   const isEOL = await isNodeEOL(currentVersion)
   if (isEOL) {
     console.error(danger)
@@ -101,7 +89,7 @@ async function main (currentVersion, platform) {
   }
 
   const coreIndex = await getCoreIndex()
-  const list = getVulnerabilityList(currentVersion, coreIndex, systemEnvironment)
+  const list = getVulnerabilityList(currentVersion, coreIndex, platform)
   if (list.length) {
     console.error(danger)
     console.error(vulnerableWarning + '\n')

--- a/test.js
+++ b/test.js
@@ -22,6 +22,12 @@ async function t () {
   assert.ok(await isNodeVulnerable('13.0.0'))
   assert.ok(await isNodeVulnerable('12.0.0'))
   assert.ok(await isNodeVulnerable('v0.12.18'))
+
+  // Platform specific
+  assert.ok(await isNodeVulnerable('19.0.0', 'linux'))
+  assert.ok(await isNodeVulnerable('18.0.0', 'win32'))
+  assert.ok(await isNodeVulnerable('14.0.0', 'android'))
+  assert.rejects(() => isNodeVulnerable('20.0.0', 'non-valid-platform'), /platform non-valid-platform is not valid. Please use aix,darwin,freebsd,linux,openbsd,sunos,win32,android/)
 }
 
 t()


### PR DESCRIPTION
### Main changes

- Added business logic to ensure that the platform is checked against the `affectedEnvironments` from the vuln database.
- Added `platform` input as optional for Github Action
- Added `os.platform()` to the CLI by default


### Notes

@RafaelGSS  I added some additional cognitive points to the `getVulnerabilityList` function and it is not easy to test with the current files structure. Should I move  `getVulnerabilityList` and `getSystemEnvironment` to a utility file so I can include proper Unit Tests?

### Context
This PR is related to https://github.com/nodejs/security-wg/pull/912, https://github.com/nodejs/security-wg/pull/914  and close #9 