### PR TITLE
Update node version in action.yml: v16 -> v18

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'checks if your Node.js installation is vulnerable to known securit
 author: 'RafaelGSS'
 
 runs:
-  using: 'node16'
+  using: 'node18'
   main: 'dist/index.js'
 
 inputs:


### PR DESCRIPTION
I'm getting a warning when using this GH action:

<img width="1499" alt="Screenshot 2024-05-21 at 17 45 10" src="https://github.com/RafaelGSS/is-my-node-vulnerable/assets/1123102/64f7d0a3-12e1-4759-bbad-2899ac7830dd">

unsure if you want to upgrade to node v20, but let's jump to v18 at least to avoid it 😄