### PR TITLE
Bump node to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'checks if your Node.js installation is vulnerable to known securit
 author: 'RafaelGSS'
 
 runs:
-  using: 'node18'
+  using: 'node20'
   main: 'dist/index.js'
 
 inputs:


### PR DESCRIPTION
It seems `node18` is not available as they skipped it: https://github.com/actions/runner/discussions/2704

Action is failing now:

<img width="1513" alt="Screenshot 2024-05-22 at 10 08 26" src="https://github.com/RafaelGSS/is-my-node-vulnerable/assets/1123102/0df4b619-b120-49b2-9fbd-aa38928cc2da">

Sorry for the mistake in my previous PR! 🙏🏻