### PR TITLE
Replace undici with native https.request

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const { request, stream, setGlobalDispatcher, Agent } = require('undici')
-const EE = require('events')
+const { request } = require('https')
+const { pipeline } = require('stream')
 const fs = require('fs')
 const path = require('path')
 const os = require('os')
@@ -9,8 +9,6 @@ const debug = require('debug')('is-my-node-vulnerable')
 const satisfies = require('semver/functions/satisfies')
 const { danger, vulnerableWarning, bold, separator, allGood } = require('./ascii')
 const nv = require('@pkgjs/nv')
-
-setGlobalDispatcher(new Agent({ connections: 20 }))
 
 const CORE_RAW_URL = 'https://raw.githubusercontent.com/nodejs/security-wg/main/vuln/core/index.json'
 
@@ -36,28 +34,55 @@ function updateLastETag (etag) {
 }
 
 async function fetchCoreIndex () {
-  const abortRequest = new EE()
-  await stream(CORE_RAW_URL, { signal: abortRequest }, ({ statusCode }) => {
-    if (statusCode !== 200) {
-      console.error('Request to Github failed. Aborting...')
-      abortRequest.emit('abort')
-      process.nextTick(() => { process.exit(1) })
-    }
-    return fs.createWriteStream(coreLocalFile, { flags: 'w', autoClose: true })
+  await new Promise((resolve) => {
+    request(CORE_RAW_URL, (res) => {
+      if (res.statusCode !== 200) {
+        console.error('Request to Github failed. Aborting...')
+        process.nextTick(() => { process.exit(1) })
+      }
+
+      const file = fs.createWriteStream(coreLocalFile)
+      pipeline(res, file, (err) => {
+        if (err) {
+          console.error(`Problem with request: ${err.message}`)
+          process.nextTick(() => { process.exit(1) })
+        } else {
+          resolve()
+        }
+      })
+    })
   })
   return readLocal(coreLocalFile)
 }
 
 async function getCoreIndex () {
-  const { headers } = await request(CORE_RAW_URL, { method: 'HEAD' })
-  if (!lastETagValue || lastETagValue !== headers.etag || !fs.existsSync(coreLocalFile)) {
-    updateLastETag(headers.etag)
-    debug('Creating local core.json')
-    return fetchCoreIndex()
-  } else {
-    debug(`No updates from upstream. Getting a cached version: ${coreLocalFile}`)
-    return readLocal(coreLocalFile)
-  }
+  return new Promise((resolve) => {
+    const req = request(CORE_RAW_URL, { method: 'HEAD' }, (res) => {
+      if (res.statusCode !== 200) {
+        console.error('Request to Github failed. Aborting...')
+        process.nextTick(() => { process.exit(1) })
+      }
+
+      res.on('data', () => {})
+
+      const { etag } = res.headers
+      if (!lastETagValue || lastETagValue !== etag || !fs.existsSync(coreLocalFile)) {
+        updateLastETag(etag)
+        debug('Creating local core.json')
+        resolve(fetchCoreIndex())
+      } else {
+        debug(`No updates from upstream. Getting a cached version: ${coreLocalFile}`)
+        resolve(readLocal(coreLocalFile))
+      }
+    })
+
+    req.on('error', (e) => {
+      console.error(`Problem with request: ${e.message}`)
+      process.nextTick(() => { process.exit(1) })
+    })
+
+    req.end()
+  })
 }
 
 const checkPlatform = platform => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "@pkgjs/nv": "^0.2.1",
         "cli-color": "^2.0.3",
         "debug": "^4.3.4",
-        "semver": "^7.3.8",
-        "undici": "^5.15.1"
+        "semver": "^7.3.8"
       },
       "bin": {
         "is-my-node-vulnerable": "index.js"
@@ -387,17 +386,6 @@
       "dev": true,
       "dependencies": {
         "semver": "^7.0.0"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -2900,14 +2888,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3115,17 +3095,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/undici": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.16.0.tgz",
-      "integrity": "sha512-KWBOXNv6VX+oJQhchXieUznEmnJMqgXMbs0xxH2t8q/FUAWSJvOSr/rMaZKnX5RIVq7JDn0JbP4BOnKG2SGXLQ==",
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.18"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "@pkgjs/nv": "^0.2.1",
     "cli-color": "^2.0.3",
     "debug": "^4.3.4",
-    "semver": "^7.3.8",
-    "undici": "^5.15.1"
+    "semver": "^7.3.8"
   },
   "devDependencies": {
     "standard": "^17.0.0",


### PR DESCRIPTION
Refs: https://github.com/RafaelGSS/is-my-node-vulnerable/issues/19

### Before

Warning is shown about Node.js undici on npm audit
```console
$ npm audit | grep undici
undici  <=5.28.3
CRLF Injection in Nodejs ‘undici’ via host - https://github.com/advisories/GHSA-5r9g-qh6m-jxff
node_modules/undici
```
### After

No warning shown about undici, as the dependency doesn't exist
```console
$ npm audit | grep undici
```

